### PR TITLE
updating supertest to 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jshint": "2.x",
     "mocha": "1.18.x",
     "sinon": "1.9.x",
-    "supertest": "0.10.x"
+    "supertest": "0.11.x"
   },
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
I only updated the supertest dependency to 0.11.x, I'll let you decide if you want to update Express dependency from 3.x to 4.x.

Fixes #1
